### PR TITLE
Allow registering items with quantity of zero

### DIFF
--- a/specs/001-item-inventory/contracts/item-schema.md
+++ b/specs/001-item-inventory/contracts/item-schema.md
@@ -6,7 +6,7 @@
 
 - `id` (string): UUID 形式の識別子。
 - `name` (string): 物品の名称。空文字不可。ストレージ内で一意。
-- `quantity` (integer): 個数。1 以上。
+- `quantity` (integer): 個数。0 以上。
 - `createdAt` (string / datetime): 初回登録日時 (サーバー設定)。
 - `updatedAt` (string / datetime): 最終更新日時 (サーバー設定)。
 
@@ -18,7 +18,7 @@
   "properties": {
     "id": { "type": "string", "format": "uuid" },
     "name": { "type": "string", "minLength": 1 },
-    "quantity": { "type": "integer", "minimum": 1 },
+    "quantity": { "type": "integer", "minimum": 0 },
     "createdAt": { "type": "string", "format": "date-time" },
     "updatedAt": { "type": "string", "format": "date-time" }
   },
@@ -30,5 +30,5 @@
 ## 契約ルール
 
 - `name` はアプリ内で一意でなければならない。
-- `quantity` は 1 以上の整数でなければならない。
+- `quantity` は 0 以上の整数でなければならない。
 - `createdAt` および `updatedAt` は API では ISO 8601 形式、画面ではローカル日時形式で表示する。

--- a/src/HomeFinder.Application/Contracts/CreateItemRequest.cs
+++ b/src/HomeFinder.Application/Contracts/CreateItemRequest.cs
@@ -9,7 +9,7 @@ public class CreateItemRequest
     [MinLength(1)]
     public string Name { get; set; } = string.Empty;
 
-    [Range(1, int.MaxValue)]
+    [Range(0, int.MaxValue)]
     public int Quantity { get; set; }
 
     /// <summary>

--- a/src/HomeFinder.Application/Contracts/UpdateItemRequest.cs
+++ b/src/HomeFinder.Application/Contracts/UpdateItemRequest.cs
@@ -8,7 +8,7 @@ public class UpdateItemRequest
     [MinLength(1)]
     public string Name { get; set; } = string.Empty;
 
-    [Range(1, int.MaxValue)]
+    [Range(0, int.MaxValue)]
     public int Quantity { get; set; }
 
     /// <summary>

--- a/src/HomeFinder.Application/Services/ItemService.cs
+++ b/src/HomeFinder.Application/Services/ItemService.cs
@@ -87,7 +87,7 @@ public class ItemService(
         try
         {
             var normalizedName = (request.Name ?? string.Empty).Trim();
-            if (string.IsNullOrWhiteSpace(normalizedName) || request.Quantity < 1)
+            if (string.IsNullOrWhiteSpace(normalizedName) || request.Quantity < 0)
             {
                 return new Result<ItemDto>(new ArgumentException("入力内容に誤りがあります。", nameof(request)));
             }
@@ -176,7 +176,7 @@ public class ItemService(
         try
         {
             var normalizedName = (request.Name ?? string.Empty).Trim();
-            if (string.IsNullOrWhiteSpace(normalizedName) || request.Quantity < 1)
+            if (string.IsNullOrWhiteSpace(normalizedName) || request.Quantity < 0)
             {
                 return new Result<ItemDto>(new ArgumentException("入力内容に誤りがあります。", nameof(request)));
             }

--- a/src/HomeFinder.UI/src/components/ItemForm.vue
+++ b/src/HomeFinder.UI/src/components/ItemForm.vue
@@ -394,7 +394,7 @@ function validate(): boolean {
     formState.fieldErrors.name = uiText.errors.nameRequired;
   }
 
-  if (formState.quantity === null || !Number.isInteger(formState.quantity) || formState.quantity < 1) {
+  if (formState.quantity === null || !Number.isInteger(formState.quantity) || formState.quantity < 0) {
     formState.fieldErrors.quantity = uiText.errors.quantityInvalid;
   }
 

--- a/src/HomeFinder.UI/src/constants/uiText.ts
+++ b/src/HomeFinder.UI/src/constants/uiText.ts
@@ -45,8 +45,8 @@ export const uiText = {
       },
       quantity: {
         label: '数量',
-        placeholder: '1',
-        helper: '1以上の整数を入力してください。',
+        placeholder: '0',
+        helper: '0以上の整数を入力してください。',
       },
       category: {
         label: 'カテゴリ',
@@ -161,7 +161,7 @@ export const uiText = {
   },
   errors: {
     nameRequired: '物品名称は必須です。',
-    quantityInvalid: '数量は1以上の整数で入力してください。',
+    quantityInvalid: '数量は0以上の整数で入力してください。',
     priceInvalid: '価格は0以上の数値で入力してください。',
     validationSummary: '入力内容に誤りがあります。',
     submitFailed: '物品登録に失敗しました。',

--- a/src/HomeFinder.UI/tests/unit/components/ItemForm.spec.ts
+++ b/src/HomeFinder.UI/tests/unit/components/ItemForm.spec.ts
@@ -33,7 +33,7 @@ describe('ItemForm', () => {
     await wrapper.find('form').trigger('submit.prevent');
 
     expect(wrapper.text()).toContain('物品名称は必須です。');
-    expect(wrapper.text()).toContain('数量は1以上の整数で入力してください。');
+    expect(wrapper.text()).toContain('数量は0以上の整数で入力してください。');
   });
 
   it('送信中は主要ボタンが無効化される', () => {

--- a/src/HomeFinder.UI/tests/unit/pages/ItemCreatePage.spec.ts
+++ b/src/HomeFinder.UI/tests/unit/pages/ItemCreatePage.spec.ts
@@ -39,11 +39,11 @@ describe('ItemCreatePage (登録モード)', () => {
     const wrapper = mount(ItemCreatePage);
 
     await wrapper.find('input[name="name"]').setValue('');
-    await wrapper.find('input[name="quantity"]').setValue('0');
+    await wrapper.find('input[name="quantity"]').setValue('-1');
     await wrapper.find('form').trigger('submit.prevent');
 
     expect(wrapper.text()).toContain('物品名称は必須です。');
-    expect(wrapper.text()).toContain('数量は1以上の整数で入力してください。');
+    expect(wrapper.text()).toContain('数量は0以上の整数で入力してください。');
   });
 
   it('API 409エラー時にメッセージを表示する', async () => {

--- a/src/tests/contract/ItemSchemaContractTests.cs
+++ b/src/tests/contract/ItemSchemaContractTests.cs
@@ -17,7 +17,7 @@ public class ItemSchemaContractTests
         Assert.Contains("\"required\": [\"id\", \"name\", \"quantity\", \"createdAt\", \"updatedAt\"]", text);
         Assert.Contains("\"additionalProperties\": false", text);
         Assert.Contains("`name` はアプリ内で一意", text);
-        Assert.Contains("`quantity` は 1 以上", text);
+        Assert.Contains("`quantity` は 0 以上", text);
     }
 
     private static string LoadContract(string filename)


### PR DESCRIPTION
Previously item registration and editing rejected a quantity of 0, requiring at least 1. This blocked recording out-of-stock items.

Relax the minimum quantity from 1 to 0 across the stack:
- CreateItemRequest/UpdateItemRequest validation ranges (1->0)
- ItemService domain guards (Quantity < 1 -> < 0); negatives still rejected
- ItemForm client-side validation, error message, helper and placeholder
- Item schema contract spec and its contract test