### PR TITLE
Allow quantity of zero at the database level

### DIFF
--- a/src/HomeFinder.Infrastructure/Data/ItemDbContext.cs
+++ b/src/HomeFinder.Infrastructure/Data/ItemDbContext.cs
@@ -42,7 +42,10 @@ public class ItemDbContext(DbContextOptions<ItemDbContext> options) : DbContext(
         // Item エンティティ設定
         modelBuilder.Entity<Item>(entity =>
         {
-            entity.ToTable("Items");
+            entity.ToTable("Items", table =>
+            {
+                table.HasCheckConstraint("CK_Items_Quantity_Positive", "[Quantity] >= 0");
+            });
             entity.HasKey(x => x.Id);
 
             entity.Property(x => x.Id).IsRequired();

--- a/src/HomeFinder.Infrastructure/Data/Migrations/20260618134800_AllowZeroQuantity.cs
+++ b/src/HomeFinder.Infrastructure/Data/Migrations/20260618134800_AllowZeroQuantity.cs
@@ -1,0 +1,39 @@
+using HomeFinder.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HomeFinder.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+[DbContext(typeof(ItemDbContext))]
+[Migration("20260618134800_AllowZeroQuantity")]
+public partial class AllowZeroQuantity : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropCheckConstraint(
+            name: "CK_Items_Quantity_Positive",
+            table: "Items");
+
+        migrationBuilder.AddCheckConstraint(
+            name: "CK_Items_Quantity_Positive",
+            table: "Items",
+            sql: "[Quantity] >= 0");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropCheckConstraint(
+            name: "CK_Items_Quantity_Positive",
+            table: "Items");
+
+        migrationBuilder.AddCheckConstraint(
+            name: "CK_Items_Quantity_Positive",
+            table: "Items",
+            sql: "[Quantity] >= 1");
+    }
+}

--- a/src/HomeFinder.Infrastructure/Data/Migrations/ItemDbContextModelSnapshot.cs
+++ b/src/HomeFinder.Infrastructure/Data/Migrations/ItemDbContextModelSnapshot.cs
@@ -200,7 +200,10 @@ namespace HomeFinder.Infrastructure.Data.Migrations
 
                     b.HasIndex("ShelfId");
 
-                    b.ToTable("Items", (string)null);
+                    b.ToTable("Items", null, t =>
+                        {
+                            t.HasCheckConstraint("CK_Items_Quantity_Positive", "[Quantity] >= 0");
+                        });
                 });
 
             modelBuilder.Entity("HomeFinder.Core.Entities.ItemHistory", b =>


### PR DESCRIPTION
The previous change relaxed quantity validation in the API and client to allow 0, but the DB still enforced CK_Items_Quantity_Positive ([Quantity]
>= 1) from the initial migration. Saving an item with quantity 0 therefore
failed with SqlException 547 (CHECK constraint conflict).

Replace the constraint to allow zero and reconcile the EF model, which had never tracked this constraint:
- New migration AllowZeroQuantity: drop + re-add CK_Items_Quantity_Positive as [Quantity] >= 0 (Down restores >= 1)
- ItemDbContext: declare the >= 0 check constraint on the Items table
- Model snapshot: reflect the constraint so the model stays in sync

The API applies migrations on startup via Database.Migrate(), so this is applied automatically on deploy. Negative quantities remain rejected.